### PR TITLE
Add interface for registering a VideoStreamObserver. 

### DIFF
--- a/ClientLib/src/main/java/com/o3dr/android/client/Drone.java
+++ b/ClientLib/src/main/java/com/o3dr/android/client/Drone.java
@@ -552,6 +552,31 @@ public class Drone {
         }
     }
 
+    public void addVideoStreamObserver(VideoStreamObserver observer) {
+        final IDroneApi droneApi = droneApiRef.get();
+        if (isStarted(droneApi)) {
+            try {
+                droneApi.addVideoStreamObserver(observer);
+            } catch (RemoteException e) {
+                handleRemoteException(e);
+            }
+        } else {
+            Log.v("Drone", "addVideoStreamObserver(): no operation performed because isStarted(droneApi)is false");
+        }
+    }
+
+    public void removeVideoStreamObserver(VideoStreamObserver observer) {
+        final IDroneApi droneApi = droneApiRef.get();
+        if (isStarted(droneApi)) {
+            try {
+                droneApi.removeVideoStreamObserver(observer);
+            } catch (RemoteException e) {
+                handleRemoteException(e);
+            }
+        } else {
+            Log.v("Drone", "addVideoStreamObserver(): no operation performed because isStarted(droneApi)is false");
+        }
+    }
     public void unregisterDroneListener(DroneListener listener) {
         if (listener == null)
             return;

--- a/ClientLib/src/main/java/com/o3dr/android/client/VideoStreamObserver.java
+++ b/ClientLib/src/main/java/com/o3dr/android/client/VideoStreamObserver.java
@@ -1,0 +1,10 @@
+package com.o3dr.android.client;
+
+import com.o3dr.services.android.lib.drone.companion.solo.video.VideoPacket;
+import com.o3dr.services.android.lib.model.IVideoStreamObserver;
+
+public abstract class VideoStreamObserver extends IVideoStreamObserver.Stub
+{
+    @Override
+    public abstract void onVideoPacketReceived(VideoPacket videoPacket);
+}

--- a/ClientLib/src/main/java/com/o3dr/android/client/apis/CameraApi.java
+++ b/ClientLib/src/main/java/com/o3dr/android/client/apis/CameraApi.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.view.Surface;
 
 import com.o3dr.android.client.Drone;
+import com.o3dr.android.client.VideoStreamObserver;
 import com.o3dr.services.android.lib.drone.attribute.error.CommandExecutionError;
 import com.o3dr.services.android.lib.model.AbstractCommandListener;
 import com.o3dr.services.android.lib.model.action.Action;
@@ -65,14 +66,16 @@ public class CameraApi extends Api {
      * @param listener Register a callback to receive update of the command execution status.
      * @since 2.6.8
      */
-    public void startVideoStream(@NonNull final Surface surface, final String tag, @NonNull Bundle videoProps, final AbstractCommandListener listener) {
-        if (surface == null || videoProps == null) {
+    public void startVideoStream(final Surface surface, final String tag, @NonNull Bundle videoProps, final AbstractCommandListener listener) {
+        if (videoProps == null) {
             postErrorEvent(CommandExecutionError.COMMAND_FAILED, listener);
             return;
         }
 
         final Bundle params = new Bundle();
-        params.putParcelable(EXTRA_VIDEO_DISPLAY, surface);
+        if (surface != null) {
+            params.putParcelable(EXTRA_VIDEO_DISPLAY, surface);
+        }
         params.putString(EXTRA_VIDEO_TAG, tag);
         params.putBundle(EXTRA_VIDEO_PROPERTIES, videoProps);
 
@@ -91,4 +94,23 @@ public class CameraApi extends Api {
         params.putString(EXTRA_VIDEO_TAG, tag);
         drone.performAsyncActionOnDroneThread(new Action(ACTION_STOP_VIDEO_STREAM, params), listener);
     }
+
+    /**
+     * Register an observer on the video stream
+     * @param observer Register an observer on the stream which will receive each video packet
+     */
+    public void addVideoStreamObserver(VideoStreamObserver observer)
+    {
+        drone.addVideoStreamObserver(observer);
+    }
+
+    /**
+     * Unregister an observer on the video stream
+     * @param observer Unregister an observer on the stream which will receive each video packet
+     */
+    public void removeVideoStreamObserver(VideoStreamObserver observer)
+    {
+        drone.removeVideoStreamObserver(observer);
+    }
+
 }

--- a/ClientLib/src/main/java/com/o3dr/android/client/apis/solo/SoloCameraApi.java
+++ b/ClientLib/src/main/java/com/o3dr/android/client/apis/solo/SoloCameraApi.java
@@ -241,10 +241,6 @@ public class SoloCameraApi extends SoloApi {
      * @since 2.5.0
      */
     public void startVideoStream(final Surface surface, final String tag, final AbstractCommandListener listener) {
-        if (surface == null) {
-            postErrorEvent(CommandExecutionError.COMMAND_FAILED, listener);
-            return;
-        }
 
         final String featureRequired = (surface == null)
                                        ? CapabilityApi.FeatureIds.SOLO_VIDEO_STREAMING_TO_OBSERVER

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/companion/solo/video/VideoPacket.aidl
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/companion/solo/video/VideoPacket.aidl
@@ -1,0 +1,5 @@
+// IVideoPacket.aidl
+package com.o3dr.services.android.lib.drone.companion.solo.video;
+
+// Declare any non-default types here with import statements
+parcelable VideoPacket;

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/companion/solo/video/VideoPacket.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/companion/solo/video/VideoPacket.java
@@ -1,0 +1,63 @@
+package com.o3dr.services.android.lib.drone.companion.solo.video;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Wrapper class for a raw video data, allowing it to be transmitted over android IPC mechanism.
+ */
+public class VideoPacket implements Parcelable
+{
+    private byte[] mBytes;
+    private int mValidLength;
+
+    public VideoPacket(byte[] bytes, int valid_length) {
+        mValidLength = valid_length;
+        if (true)
+        {
+            this.mBytes = new byte[valid_length];
+            System.arraycopy(bytes, 0, this.mBytes, 0, valid_length);
+        } else
+        {
+            this.mBytes = bytes;
+        }
+    }
+
+    public byte[] data()
+    {
+        return this.mBytes;
+    }
+    public int size()
+    {
+        return mValidLength;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(this.mValidLength);
+        dest.writeByteArray(this.mBytes, 0, this.mValidLength);
+    }
+
+    private VideoPacket(Parcel in) {
+        this.mValidLength = in.readInt();
+        this.mBytes= new byte[this.mValidLength];
+        in.readByteArray(this.mBytes);
+    }
+
+    public static final Parcelable.Creator<VideoPacket> CREATOR = new Parcelable.Creator<VideoPacket>() {
+        public VideoPacket createFromParcel(Parcel source) {
+            return new VideoPacket(source);
+        }
+
+        public VideoPacket[] newArray(int size) {
+            return new VideoPacket[size];
+        }
+    };
+}

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/model/IDroneApi.aidl
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/model/IDroneApi.aidl
@@ -3,6 +3,7 @@ package com.o3dr.services.android.lib.model;
 
 import com.o3dr.services.android.lib.model.IObserver;
 import com.o3dr.services.android.lib.model.IMavlinkObserver;
+import com.o3dr.services.android.lib.model.IVideoStreamObserver;
 import com.o3dr.services.android.lib.model.action.Action;
 import com.o3dr.services.android.lib.model.ICommandListener;
 
@@ -56,6 +57,19 @@ interface IDroneApi {
     * @param observer the observer to remove.
     */
     oneway void removeMavlinkObserver(IMavlinkObserver observer);
+
+    /**
+    * Register a listener to receive encoded video data.
+    * @param observer the observer to register.
+    */
+    oneway void addVideoStreamObserver(IVideoStreamObserver observer);
+
+    /**
+    * Removes an encoded video data listener.
+    * @param observer the observer to remove.
+    */
+    oneway void removeVideoStreamObserver(IVideoStreamObserver observer);
+
 
     /**
     * Performs an action among the set exposed by the api.

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/model/IVideoStreamObserver.aidl
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/model/IVideoStreamObserver.aidl
@@ -1,0 +1,13 @@
+// IVideoStreamObserver.aidl
+package com.o3dr.services.android.lib.model;
+
+import com.o3dr.services.android.lib.drone.companion.solo.video.VideoPacket;
+
+oneway interface IVideoStreamObserver {
+
+    /**
+    * Notify observer that the specified encoded video packet was received.
+    * @param messageWrapper Wrapper for the received raw video data.
+    */
+    void onVideoPacketReceived(in VideoPacket videoPacket);
+}

--- a/ServiceApp/src/org/droidplanner/services/android/core/drone/DroneManager.java
+++ b/ServiceApp/src/org/droidplanner/services/android/core/drone/DroneManager.java
@@ -531,6 +531,7 @@ public class DroneManager implements Drone, MAVLinkStreams.MavlinkInputStream, D
                         switch (featureId) {
 
                             case CapabilityApi.FeatureIds.SOLO_VIDEO_STREAMING:
+                            case CapabilityApi.FeatureIds.SOLO_VIDEO_STREAMING_TO_OBSERVER:
                             case CapabilityApi.FeatureIds.COMPASS_CALIBRATION:
                                 if (this.isCompanionComputerEnabled()) {
                                     CommonApiUtils.postSuccessEvent(listener);

--- a/ServiceApp/src/org/droidplanner/services/android/core/drone/autopilot/generic/GenericMavLinkDrone.java
+++ b/ServiceApp/src/org/droidplanner/services/android/core/drone/autopilot/generic/GenericMavLinkDrone.java
@@ -124,6 +124,9 @@ public abstract class GenericMavLinkDrone implements MavLinkDrone {
     public void stopVideoStream(String appId, String currentVideoTag, final ICommandListener listener) {
         videoMgr.stopVideoStream(appId, currentVideoTag, listener);
     }
+    public void setVideoStreamListener(VideoManager.VideoStreamListener listener) {
+        videoMgr.setVideoStreamListener(listener);
+    }
 
     /**
      * Stops the video stream if the current owner is the passed argument.

--- a/ServiceApp/src/org/droidplanner/services/android/utils/CommonApiUtils.java
+++ b/ServiceApp/src/org/droidplanner/services/android/utils/CommonApiUtils.java
@@ -66,6 +66,7 @@ import org.droidplanner.services.android.core.mission.survey.SurveyImpl;
 import org.droidplanner.services.android.core.mission.waypoints.StructureScannerImpl;
 import org.droidplanner.services.android.core.survey.Footprint;
 import org.droidplanner.services.android.utils.file.IO.ParameterMetadataLoader;
+import org.droidplanner.services.android.utils.video.VideoManager;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -1050,5 +1051,15 @@ public class CommonApiUtils {
 
         final GenericMavLinkDrone mavLinkDrone = (GenericMavLinkDrone) drone;
         mavLinkDrone.stopVideoStream(appId, videoTag, listener);
+    }
+
+    public static void setVideoStreamListener(Drone drone, VideoManager.VideoStreamListener listener)
+    {
+        if(!(drone instanceof GenericMavLinkDrone)){
+            return;
+        }
+
+        final GenericMavLinkDrone mavLinkDrone = (GenericMavLinkDrone) drone;
+        mavLinkDrone.setVideoStreamListener(listener);
     }
 }

--- a/ServiceApp/src/org/droidplanner/services/android/utils/SoloApiUtils.java
+++ b/ServiceApp/src/org/droidplanner/services/android/utils/SoloApiUtils.java
@@ -11,6 +11,7 @@ import com.o3dr.services.android.lib.drone.companion.solo.controller.SoloControl
 import com.o3dr.services.android.lib.drone.companion.solo.tlv.SoloButtonSettingSetter;
 import com.o3dr.services.android.lib.drone.companion.solo.tlv.TLVPacket;
 import com.o3dr.services.android.lib.model.ICommandListener;
+import com.o3dr.services.android.lib.model.IVideoStreamObserver;
 
 import org.droidplanner.services.android.core.drone.DroneManager;
 import org.droidplanner.services.android.core.drone.autopilot.Drone;
@@ -116,5 +117,4 @@ public class SoloApiUtils {
         final SoloComp soloComp = arduSolo.getSoloComp();
         soloComp.updateEUTxPowerCompliance(isCompliant, listener);
     }
-
 }

--- a/ServiceApp/src/org/droidplanner/services/android/utils/video/DecoderListener.java
+++ b/ServiceApp/src/org/droidplanner/services/android/utils/video/DecoderListener.java
@@ -7,7 +7,11 @@ public interface DecoderListener {
 
     void onDecodingStarted();
 
+    boolean wantDecoderInput();
+
     void onDecodingError();
+
+    void onDecoderInput(byte[] bytes, int validLength);
 
     void onDecodingEnded();
 

--- a/samples/StarterApp/src/main/res/layout/activity_main.xml
+++ b/samples/StarterApp/src/main/res/layout/activity_main.xml
@@ -271,6 +271,11 @@
                     android:text="Stop streaming"/>
 
             </LinearLayout>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:id="@+id/video_stream_stats"
+                    android:visibility="invisible"/>
                 <TextureView
                     android:id="@+id/video_content"
                     android:layout_width="match_parent"


### PR DESCRIPTION
The VideoStreamObserver's onVideoPacketReceived method is called for each reconstructed h264 access unit. Because the intention is to allow all decoding to be handled by the client, if an observer is registered a Surface is not required when startVideoStream is called.

Motivations for these changes:

*  To be able to render to a Surface which is of the same dimensions as the video
   stream as signalled by the sequence parameter set.
*  Parse slices and e.g. render only Iframes
*  Save raw h264 stream for debugging purposes