### PR TITLE
Fixes Vagrantfile to allow Sphinx docs to build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,7 +61,7 @@ Vagrant.configure(2) do |config|
 		./gradlew :ClientLib:mobile:clean :ClientLib:mobile:androidJavadocs
 
 		#echo "[DroneKit]: Sphinx Docs "
-		cd docs/
+		cd /vagrant/doc
 		make clean
 		make html
 	SHELL


### PR DESCRIPTION
This allows Sphinx docs to build (previously this was pointing at dir "docs" rather than "doc").