### PR TITLE
Initialize coordinate in Land default constructor

### DIFF
--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/Land.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/Land.java
@@ -13,7 +13,7 @@ public class Land extends BaseSpatialItem implements android.os.Parcelable {
 
     public Land(){
         super(MissionItemType.LAND);
-        super.coordinate = new LatLongAlt(0.0, 0.0, 0.0);
+        super.setCoordinate(new LatLongAlt(0.0, 0.0, 0.0));
     }
 
     public Land(Land copy){

--- a/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/Land.java
+++ b/ClientLib/src/main/java/com/o3dr/services/android/lib/drone/mission/item/spatial/Land.java
@@ -13,6 +13,7 @@ public class Land extends BaseSpatialItem implements android.os.Parcelable {
 
     public Land(){
         super(MissionItemType.LAND);
+        super.coordinate = new LatLongAlt(0.0, 0.0, 0.0);
     }
 
     public Land(Land copy){


### PR DESCRIPTION
When creating a new Land object using the default constructor, the coordinate field inherited from BaseSpatialItem is initialized to a LatLongAlt object with its values set to 0. This means that if a Land object is created without explicitly setting its coordinate field, the drone will simply land at its current position.

This PR fixes issue #397.