### PR TITLE
Add a guard against dividing by 0 when a 0 value is passed into the connectionParams

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/manager/MavLinkDroneManager.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/manager/MavLinkDroneManager.java
@@ -184,7 +184,10 @@ public class MavLinkDroneManager extends DroneManager<MavLinkDrone, MAVLinkPacke
     }
 
     private void updateDroneStreamRate(ConnectionParameter connParams) {
-        int eventsDispatchingRate = Math.round(1000L / connParams.getEventsDispatchingPeriod());
+        // Prevent divide by zero
+        long eventDispatchPeriod = connParams.getEventsDispatchingPeriod() == 0L ? 1L : connParams.getEventsDispatchingPeriod();
+
+        int eventsDispatchingRate = Math.round(1000L / eventDispatchPeriod);
 
         boolean updateComplete;
         do {


### PR DESCRIPTION
Backstory:

MPCC on the Solo app needs all events dispatched immediately, so no buffer for SoloMessage events. So I went to modify the connectionparams to have the eventDispatchPeriod of 0 only to discover that this crashes the app due to a divide by zero error