### PR TITLE
Take eventDispatchPeriod into account when converting a udpconnection to a Solo connection

### DIFF
--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/api/DroneApi.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/api/DroneApi.java
@@ -235,7 +235,7 @@ public final class DroneApi extends IDroneApi.Stub implements DroneInterfaces.On
         }
 
         if (SoloConnection.isUdpSoloConnection(context, connParams)) {
-            ConnectionParameter update = SoloConnection.getSoloConnectionParameterFromUdp(context, connParams.getTLogLoggingUri());
+            ConnectionParameter update = SoloConnection.getSoloConnectionParameterFromUdp(context, connParams);
             if (update != null) {
                 return update;
             }

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/communication/connection/SoloConnection.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/communication/connection/SoloConnection.java
@@ -14,6 +14,7 @@ import com.o3dr.services.android.lib.gcs.link.LinkConnectionStatus;
 import org.droidplanner.services.android.impl.utils.connection.WifiConnectionHandler;
 
 import java.io.IOException;
+import java.sql.Connection;
 import java.util.List;
 
 import timber.log.Timber;
@@ -201,13 +202,13 @@ public class SoloConnection extends AndroidMavLinkConnection implements WifiConn
         }
     }
 
-    public static ConnectionParameter getSoloConnectionParameterFromUdp(Context context, Uri tLogLoggingUri){
+    public static ConnectionParameter getSoloConnectionParameterFromUdp(Context context, ConnectionParameter udpConnectionParameters){
         if(context == null)
             return null;
 
         final String wifiSsid = WifiConnectionHandler.getCurrentWifiLink((WifiManager) context.getSystemService(Context.WIFI_SERVICE));
         if(WifiConnectionHandler.isSoloWifi(wifiSsid)){
-            return ConnectionParameter.newSoloConnection(wifiSsid, null, tLogLoggingUri);
+            return ConnectionParameter.newSoloConnection(wifiSsid, null, udpConnectionParameters.getTLogLoggingUri(), udpConnectionParameters.getEventsDispatchingPeriod());
         }
 
         return null;


### PR DESCRIPTION
Issue: the conversion of a UDP connection to a Solo connection did not take into account the eventDispatchPeriod defined for the udp connection, so for all solos, the default eventDispatchPeriod was used (200L). This breaks MPCC.

Fix: take eventDispatchPeriod into account