### PR TITLE
Have msg_statustext.toString show readable text

### DIFF
--- a/dependencyLibs/Mavlink/src/com/MAVLink/common/msg_statustext.java
+++ b/dependencyLibs/Mavlink/src/com/MAVLink/common/msg_statustext.java
@@ -124,7 +124,7 @@ public class msg_statustext extends MAVLinkMessage{
     * Returns a string with the MSG name and data
     */
     public String toString(){
-        return "MAVLINK_MSG_ID_STATUSTEXT -"+" severity:"+severity+" text:"+text+"";
+        return "MAVLINK_MSG_ID_STATUSTEXT -"+" severity:"+severity+" text:"+getText()+"";
     }
 }
         


### PR DESCRIPTION
`text` is a `byte []`, so it does not render the text message when `toString()` is called