### PR TITLE
MavLinkDrone: Fixes #443 and makes sysid/compid use the expected shor…

### DIFF
--- a/ClientLib/build.gradle
+++ b/ClientLib/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'com.getkeepsafe.dexcount'
 ext {
     VERSION_MAJOR = 3
     VERSION_MINOR = 0
-    VERSION_PATCH = 1
-    VERSION_SUFFIX = "release"
+    VERSION_PATCH = 2
+    VERSION_SUFFIX = "beta1"
 
     PUBLISH_ARTIFACT_ID = 'dronekit-android'
     PUBLISH_VERSION = generateVersionName("", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_SUFFIX)

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/MAVLink/MavLinkStreamRates.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/MAVLink/MavLinkStreamRates.java
@@ -7,7 +7,7 @@ import org.droidplanner.services.android.impl.communication.model.DataLink.DataL
 
 public class MavLinkStreamRates {
 
-	public static void setupStreamRates(DataLinkProvider MAVClient, byte sysid, byte compid,
+	public static void setupStreamRates(DataLinkProvider MAVClient, short sysid, short compid,
 			int extendedStatus, int extra1, int extra2, int extra3, int position, int rcChannels,
 			int rawSensors, int rawControler) {
 		requestMavlinkDataStream(MAVClient, sysid, compid, MAV_DATA_STREAM.MAV_DATA_STREAM_EXTENDED_STATUS,
@@ -22,8 +22,8 @@ public class MavLinkStreamRates {
 		requestMavlinkDataStream(MAVClient, sysid, compid, MAV_DATA_STREAM.MAV_DATA_STREAM_RC_CHANNELS, rcChannels);
 	}
 
-	private static void requestMavlinkDataStream(DataLinkProvider mAVClient, byte sysid,
-			byte compid, int stream_id, int rate) {
+	private static void requestMavlinkDataStream(DataLinkProvider mAVClient, short sysid,
+			short compid, int stream_id, int rate) {
 		msg_request_data_stream msg = new msg_request_data_stream();
 		msg.target_system = sysid;
 		msg.target_component = compid;

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/DroneVariable.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/DroneVariable.java
@@ -9,6 +9,10 @@ import com.o3dr.services.android.lib.model.ICommandListener;
 import timber.log.Timber;
 
 public class DroneVariable<T extends MavLinkDrone> {
+
+	static int UNSIGNED_BYTE_MIN_VALUE = 0;
+	static int UNSIGNED_BYTE_MAX_VALUE = 255;
+
 	protected T myDrone;
 
 	public DroneVariable(T myDrone) {
@@ -75,4 +79,13 @@ public class DroneVariable<T extends MavLinkDrone> {
 			});
 		}
 	}
+
+	public static short validateToUnsignedByteRange(int id){
+		if(id < UNSIGNED_BYTE_MIN_VALUE || id > UNSIGNED_BYTE_MAX_VALUE){
+			throw new IllegalArgumentException("Value is outside of the range of an sysid/compid byte: " + id);
+		}
+		return (short)id;
+	}
+
+
 }

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/MavLinkDrone.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/MavLinkDrone.java
@@ -27,9 +27,9 @@ public interface MavLinkDrone extends Drone {
 
     void onMavLinkMessageReceived(MAVLinkMessage message);
 
-    public byte getSysid();
+    public short getSysid();
 
-    public byte getCompid();
+    public short getCompid();
 
     public State getState();
 

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/autopilot/generic/GenericMavLinkDrone.java
@@ -237,12 +237,13 @@ public class GenericMavLinkDrone implements MavLinkDrone {
     }
 
     @Override
-    public byte getSysid() {
+    public short getSysid() {
+
         return heartbeat.getSysid();
     }
 
     @Override
-    public byte getCompid() {
+    public short getCompid() {
         return heartbeat.getCompid();
     }
 

--- a/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/variables/HeartBeat.java
+++ b/ClientLib/src/main/java/org/droidplanner/services/android/impl/core/drone/variables/HeartBeat.java
@@ -24,8 +24,8 @@ public class HeartBeat extends DroneVariable implements OnDroneListener<MavLinkD
     protected static final int NORMAL_HEARTBEAT = 2;
 
     protected int heartbeatState = FIRST_HEARTBEAT;
-    private byte sysid = 1;
-    private byte compid = 1;
+    private short sysid = 1;
+    private short compid = 1;
 
     /**
      * Stores the version of the mavlink protocol.
@@ -46,11 +46,11 @@ public class HeartBeat extends DroneVariable implements OnDroneListener<MavLinkD
         myDrone.addDroneListener(this);
     }
 
-    public byte getSysid() {
+    public short getSysid() {
         return sysid;
     }
 
-    public byte getCompid() {
+    public short getCompid() {
         return compid;
     }
 
@@ -64,8 +64,8 @@ public class HeartBeat extends DroneVariable implements OnDroneListener<MavLinkD
     public void onHeartbeat(MAVLinkMessage msg) {
         msg_heartbeat heartBeatMsg = msg instanceof msg_heartbeat ? (msg_heartbeat) msg : null;
         if(heartBeatMsg != null){
-            sysid = (byte) msg.sysid;
-            compid = (byte) msg.compid;
+            sysid  = validateToUnsignedByteRange(msg.sysid);
+            compid = validateToUnsignedByteRange(msg.compid);
             mMavlinkVersion = heartBeatMsg.mavlink_version;
         }
 


### PR DESCRIPTION
…t type

sysid/compid need to use short with the current library and not byte as it stores the values as an unsigned 0-255 value in the short variable. Missing the conversion will cause a crash.

This PR can serve as a discussion as to the correct fix. But I think it should be along the lines that mysid/compid needs to be represented as short (like in the library) or the java mavlink lib needs to represent unsigned bytes as signed bytes and conversion only happens when the byte is displayed to the user.


Exception is caused here

https://github.com/dronekit/dronekit-android/blob/develop/dependencyLibs/Mavlink/src/com/MAVLink/Messages/MAVLinkPayload.java#L140

When the target system id (or component id) is -127 to -1 i.e. 128-255)
https://github.com/dronekit/dronekit-android/blob/4f965d97a3dad087390a947d0669683f1895949a/dependencyLibs/Mavlink/src/com/MAVLink/common/msg_request_data_stream.java#L62